### PR TITLE
Class-Based Serialization Support

### DIFF
--- a/src/main/java/dev/willbanders/storm/Storm.java
+++ b/src/main/java/dev/willbanders/storm/Storm.java
@@ -1,17 +1,29 @@
 package dev.willbanders.storm;
 
 import dev.willbanders.storm.config.Node;
+import dev.willbanders.storm.config.Scope;
 import dev.willbanders.storm.format.storm.StormGenerator;
 import dev.willbanders.storm.format.storm.StormParser;
 import dev.willbanders.storm.serializer.primitive.*;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
 public final class Storm {
 
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE})
+    public @interface Serialized {}
+
+    public static final Scope SCOPE = new Scope();
     public static final AnySerializer ANY = AnySerializer.INSTANCE;
     public static final NullableSerializer<Object> ANY_NULLABLE = NullableSerializer.INSTANCE;
     public static final OptionalSerializer<Object> ANY_OPTIONAL = OptionalSerializer.INSTANCE;
@@ -33,6 +45,7 @@ public final class Storm {
     public static final EnumSerializer<?> ENUM = EnumSerializer.INSTANCE;
     public static final TupleSerializer<?> TUPLE = TupleSerializer.INSTANCE;
     public static final UnionSerializer<?> UNION = UnionSerializer.INSTANCE;
+    public static final ClassSerializer<?> CLASS = ClassSerializer.INSTANCE;
 
     public static Node deserialize(String input) {
         return StormParser.parse(input);
@@ -42,6 +55,29 @@ public final class Storm {
         StringWriter writer = new StringWriter();
         StormGenerator.generate(node, new PrintWriter(writer));
         return writer.toString();
+    }
+
+    static {
+        SCOPE.register(boolean.class, BOOLEAN);
+        SCOPE.register(byte.class, BYTE);
+        SCOPE.register(short.class, SHORT);
+        SCOPE.register(int.class, INTEGER);
+        SCOPE.register(long.class, LONG);
+        SCOPE.register(float.class, FLOAT);
+        SCOPE.register(double.class, DOUBLE);
+        SCOPE.register(char.class, CHARACTER);
+        SCOPE.register(Object.class, ANY);
+        SCOPE.register(Boolean.class, BOOLEAN);
+        SCOPE.register(Byte.class, BYTE);
+        SCOPE.register(Short.class, SHORT);
+        SCOPE.register(Integer.class, INTEGER);
+        SCOPE.register(Long.class, LONG);
+        SCOPE.register(BigInteger.class, BIG_INTEGER);
+        SCOPE.register(Float.class, FLOAT);
+        SCOPE.register(Double.class, DOUBLE);
+        SCOPE.register(BigDecimal.class, BIG_DECIMAL);
+        SCOPE.register(Character.class, CHARACTER);
+        SCOPE.register(String.class, STRING);
     }
 
 }

--- a/src/main/java/dev/willbanders/storm/config/Node.java
+++ b/src/main/java/dev/willbanders/storm/config/Node.java
@@ -3,6 +3,7 @@ package dev.willbanders.storm.config;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import dev.willbanders.storm.Storm;
 import dev.willbanders.storm.serializer.SerializationException;
 import dev.willbanders.storm.serializer.Serializer;
 
@@ -393,8 +394,8 @@ public final class Node {
     }
 
     /**
-     * Deserializes a value from the node located at the given path relative
-     * to this node using the given serializer.
+     * Deserializes a value from the node located at the given path relative to
+     * this node using the given serializer.
      *
      * @throws SerializationException if the node could not be deserialized
      * @see #get(String)
@@ -405,10 +406,31 @@ public final class Node {
     }
 
     /**
+     * Deserializes a value using the serializer registered for the given class.
+     *
+     * @throws SerializationException if the node could not be deserialized
+     */
+    public <T> T get(Class<T> clazz) throws SerializationException {
+        return get(Storm.SCOPE.get(clazz));
+    }
+
+    /**
+     * Deserializes a value from the node located at the given path relative to
+     * this node using the serializer registered for the given class.
+     *
+     * @throws SerializationException if the node could not be deserialized
+     * @see #get(Class)
+     * @see #get(String, Serializer)
+     */
+    public <T> T get(String path, Class<T> clazz) throws SerializationException {
+        return get(path, Storm.SCOPE.get(clazz));
+    }
+
+    /**
      * Reserializes the value to this node using the given serializer.
      *
-     * @throws SerializationException if the node could not be serialized
-     * @see Serializer#reserialize(Node, Object) 
+     * @throws SerializationException if the value could not be reserialized
+     * @see Serializer#reserialize(Node, Object)
      */
     public <T> void set(T value, Serializer<T> serializer) throws SerializationException {
         serializer.reserialize(this, value);
@@ -418,12 +440,47 @@ public final class Node {
      * Reserializes the value to the node located at the given path relative to
      * this node using the given serializer.
      *
-     * @throws SerializationException if the node could not be serialized
+     * @throws SerializationException if the value could not be reserialized
      * @see #get(String)
      * @see #set(Object, Serializer)
      */
     public <T> void set(String path, T value, Serializer<T> serializer) throws SerializationException {
         get(path).set(value, serializer);
+    }
+
+    /**
+     * Reserializes the value to this node using the serializer registered for
+     * the value's class.
+     *
+     * @throws SerializationException if the value could not be reserialized
+     */
+    public <T> void set(T value) throws SerializationException {
+        set(value, Storm.SCOPE.get((Class<T>) value.getClass()));
+    }
+
+    /**
+     * Reserializes the value to this node using the serializer registered for
+     * the value's class.
+     *
+     * @throws SerializationException if the value could not be reserialized
+     * @see #get(String)
+     * @see #set(Object)
+     */
+    public <T> void set(String path, T value) throws SerializationException {
+        get(path).set(value);
+    }
+
+    /**
+     * Reserialize the value to this node using the given serializer. This
+     * method is defined to avoid resolution ambiguity between {@link
+     * #set(Object, Serializer)} and {@link #set(String, Object)} for strings,
+     * since both methods could apply.
+     *
+     * @throws SerializationException if the value could not be reserialized
+     * @see Serializer#reserialize(Node, Object)
+     */
+    public void set(String value, Serializer<String> serializer) throws SerializationException {
+        serializer.reserialize(this, value);
     }
 
 }

--- a/src/main/java/dev/willbanders/storm/config/Scope.java
+++ b/src/main/java/dev/willbanders/storm/config/Scope.java
@@ -1,0 +1,23 @@
+package dev.willbanders.storm.config;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import dev.willbanders.storm.serializer.Serializer;
+
+import java.util.Map;
+
+public class Scope {
+
+    private final Map<Class<?>, Serializer<?>> serializers = Maps.newHashMap();
+
+    public <T> Serializer<T> get(Class<T> clazz) {
+        Preconditions.checkArgument(serializers.containsKey(clazz), "No serializer is registered for %s.", clazz);
+        return (Serializer<T>) serializers.get(clazz);
+    }
+
+    public <T> void register(Class<T> clazz, Serializer<T> serializer) {
+        Preconditions.checkState(!serializers.containsKey(clazz), "A serializer is already registered for %s.", clazz);
+        serializers.put(clazz, serializer);
+    }
+
+}

--- a/src/main/java/dev/willbanders/storm/serializer/primitive/ClassSerializer.java
+++ b/src/main/java/dev/willbanders/storm/serializer/primitive/ClassSerializer.java
@@ -1,0 +1,190 @@
+package dev.willbanders.storm.serializer.primitive;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import dev.willbanders.storm.Storm;
+import dev.willbanders.storm.config.Node;
+import dev.willbanders.storm.serializer.SerializationException;
+import dev.willbanders.storm.serializer.Serializer;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ClassSerializer<T> implements Serializer<T> {
+
+    public static final ClassSerializer<Object> INSTANCE = new ClassSerializer<>(Object.class);
+
+    private final Class<T> clazz;
+
+    private ClassSerializer(Class<T> clazz) {
+        this.clazz = clazz;
+    }
+
+    @Override
+    public T deserialize(Node node) throws SerializationException {
+        return node.get(clazz);
+    }
+
+    @Override
+    public void reserialize(Node node, T value) throws SerializationException {
+        node.set(value);
+    }
+
+    /**
+     * Returns a new serializer for instances of the given class. The class must
+     * be annotated with {@link Storm.Serialized}, and uses either method-based
+     * or field-based serialization as defined below:
+     *
+     * Method-based serialization is used if a {@code deserialize(Node)} method
+     * exists. This method must be static and returns the given class. If a
+     * {@code reserialize(Node, GivenClass)} method exists, reserialization is
+     * supported. This method must also be static and returns void.
+     *
+     * Field-based serialization is used if a {@code deserialize(Node)} method
+     * does not exist. The class must have a constructor taking zero arguments
+     * (which uses reflection to initialize fields) or a constructor taking the
+     * types of each field in the order they are defined in the given class.
+     * Reserialization is always supported through reflection on each field.
+     */
+    public <T> Serializer<T> of(Class<T> clazz) {
+        Preconditions.checkArgument(clazz.getDeclaredAnnotation(Storm.Serialized.class) != null, "Missing @Storm.Serialized annotation for class %s.", clazz.getName());
+        Method deserialize = getMethod(clazz, clazz, "deserialize", Node.class).orElse(null);
+        if (deserialize == null) {
+            Map<String, Field> fields = Arrays.stream(clazz.getDeclaredFields())
+                    .peek(f -> f.setAccessible(true))
+                    .collect(Collectors.toMap(Field::getName, f -> f));
+            Constructor<T> constructor = getConstructor(clazz)
+                    .orElseGet(() -> getConstructor(clazz, fields.values().stream()
+                            .map(Field::getType)
+                            .toArray(Class[]::new))
+                            .orElseThrow(() -> new IllegalArgumentException("No applicable constructor for field serialization in class " + clazz.getName() + ".")));
+            return new Fields<>(clazz, fields, constructor);
+        } else {
+            Optional<Method> reserialize = getMethod(clazz, void.class, "reserialize", Node.class, clazz);
+            return new Methods<>(clazz, deserialize, reserialize);
+        }
+    }
+
+    private static <T> Optional<Constructor<T>> getConstructor(Class<T> clazz, Class<?>... parameters) {
+        try {
+            Constructor<T> constructor = clazz.getDeclaredConstructor(parameters);
+            constructor.setAccessible(true);
+            return Optional.of(constructor);
+        } catch (NoSuchMethodException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<Method> getMethod(Class<?> clazz, Class<?> returns, String name, Class<?>... parameters) {
+        try {
+            Method method = clazz.getDeclaredMethod(name, parameters);
+            Preconditions.checkArgument(Modifier.isStatic(method.getModifiers()), "Serialization methods must be static for method %s.", method);
+            Preconditions.checkArgument(method.getReturnType().equals(returns), "Return type must be %s for method %s.", returns.getName(), method);
+            method.setAccessible(true);
+            return Optional.of(method);
+        } catch (NoSuchMethodException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static final class Fields<T> extends ClassSerializer<T> {
+
+        private final Map<String, Field> fields;
+        private final Constructor<T> constructor;
+
+        private Fields(Class<T> clazz, Map<String, Field> fields, Constructor<T> constructor) {
+            super(clazz);
+            this.fields = fields;
+            this.constructor = constructor;
+        }
+
+        @Override
+        public T deserialize(Node node) throws SerializationException {
+            if (node.getType() != Node.Type.OBJECT) {
+                throw new SerializationException(node, "Expected an object value.");
+            } else if (!fields.keySet().equals(node.getMap().keySet())) {
+                Set<String> expected = Sets.difference(fields.keySet(), node.getMap().keySet());
+                Set<String> unexpected = Sets.difference(node.getMap().keySet(), fields.keySet());
+                throw new SerializationException(node, "Expected properties " + expected + " and not " + unexpected + ".");
+            }
+            Map<String, Object> values = Maps.newHashMap();
+            for (Map.Entry<String, Field> entry : fields.entrySet()) {
+                values.put(entry.getKey(), node.get(entry.getKey(), entry.getValue().getType()));
+            }
+            try {
+                if (constructor.getParameterCount() == 0) {
+                    T instance = constructor.newInstance();
+                    for (Field field : fields.values()) {
+                        field.set(instance, values.get(field.getName()));
+                    }
+                    return instance;
+                } else {
+                    return constructor.newInstance(fields.values().stream()
+                            .map(f -> values.get(f.getName()))
+                            .toArray(Object[]::new));
+                }
+            } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+                throw new SerializationException(node, e.getMessage());
+            }
+        }
+
+        @Override
+        public void reserialize(Node node, T value) throws SerializationException {
+            if (value == null) {
+                throw new SerializationException(node, "Expected a non-null value.");
+            }
+            try {
+                for (Map.Entry<String, Field> entry : fields.entrySet()) {
+                    node.set(entry.getKey(), entry.getValue().get(value));
+                }
+            } catch (IllegalAccessException e) {
+                throw new SerializationException(node, e.getMessage());
+            }
+        }
+
+    }
+
+    private static final class Methods<T> extends ClassSerializer<T> {
+
+        private final Method deserialize;
+        private final Optional<Method> reserialize;
+
+        private Methods(Class<T> clazz, Method deserialize, Optional<Method> reserialize) {
+            super(clazz);
+            this.deserialize = deserialize;
+            this.reserialize = reserialize;
+        }
+
+        @Override
+        public T deserialize(Node node) throws SerializationException {
+            try {
+                return (T) deserialize.invoke(null, node);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new SerializationException(node, e.getMessage());
+            }
+        }
+
+        @Override
+        public void reserialize(Node node, T value) throws SerializationException {
+            if (!reserialize.isPresent()) {
+                throw new SerializationException(node, "Reserialization is not supported for this serializer.");
+            }
+            try {
+                reserialize.get().invoke(null, node, value);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new SerializationException(node, e.getMessage());
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Description

Class-based serialization is primarily for creating a `Serializer` instance based on the fields of the class. Additionally, I am also including the option of method-based serialization, which is simply static `deserialize(Node)` and `reserialize(Node, obj)` implementing the `Serializer` interface.

### TODO

There are a few pieces remaining which need to be resolved:

 - Serialization for subtypes, like `ArrayList`. The general solution to subtyping serialization is difficult, but it may be acceptable for now to allow any subtype to be reserialized.
 - Serialization for generics (+ arrays), especially for field-based serialization to work. This will likely require some reflection trickery.
 - Additional customization around serialization, for example what fields are serialized, the names of fields, and so on. If there are not supported, we need clear reasoning as to why.
 - The scope system should probably not be global, and instead be contained with some type of node options. This allows different serializers to be used as needed.
